### PR TITLE
Update post.ts to properly return the latest post

### DIFF
--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -9,7 +9,7 @@ export const getCategories = async () => {
 export const getPosts = async (max?: number) => {
 	return (await getCollection('blog'))
 		.filter((post) => !post.data.draft)
-		.sort((a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf())
+		.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
 		.slice(0, max)
 }
 


### PR DESCRIPTION
The previous function returns all posts in ascending order of pubDate, i.e. the oldest published post will be displayed first, which doesn't fit the purpose of getting the latest posts. I did small changes to the `sort` function, and it should works as we expect.

Have a nice day!