### PR TITLE
Fix case sensitivity issue with tags

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -5,7 +5,7 @@ export interface Props {
 const { tag } = Astro.props
 ---
 
-<a href={`/tags/${tag}`} aria-label={tag}>
+<a href={`/tags/${tag.toLowerCase()}`} aria-label={tag}>
 	<span
 		class='bg-indigo-600 font-semibold text-white dark:bg-indigo-900 dark:text-white shadow text-sm w-fit px-2 py-1 md:px-5 md:py-2 rounded-full'
 	>

--- a/src/pages/post/[...slug].astro
+++ b/src/pages/post/[...slug].astro
@@ -22,8 +22,9 @@ type Props = CollectionEntry<'blog'>
 const post = Astro.props
 const MAX_POSTS = 3
 const getRelatedPosts = (post: Props) => {
+	const lowercaseTags = post.data.tags.map((tag) => tag.toLowerCase())
 	const relatedPosts = posts.filter(
-		(p) => p.slug !== post.slug && p.data.tags.some((t) => post.data.tags.includes(t))
+		(p) => p.slug !== post.slug && p.data.tags.some((t) => lowercaseTags.includes(t.toLowerCase()))
 	)
 	return relatedPosts.slice(0, MAX_POSTS)
 }

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -15,13 +15,22 @@ export const getPosts = async (max?: number) => {
 
 export const getTags = async () => {
 	const posts = await getCollection('blog')
-	const tags = new Set(posts.map((post) => post.data.tags).flat())
+	const tags = new Set()
+	posts.forEach((post) => {
+		post.data.tags.forEach((tag) => {
+			tags.add(tag.toLowerCase())
+		})
+	})
+
 	return Array.from(tags)
 }
 
 export const getPostByTag = async (tag: string) => {
 	const posts = await getPosts()
-	return posts.filter((post) => post.data.tags.includes(tag))
+	const lowercaseTag = tag.toLowerCase()
+	return posts.filter((post) => {
+		return post.data.tags.some((postTag) => postTag.toLowerCase() === lowercaseTag)
+	})
 }
 
 export const filterPostsByCategory = async (category: string) => {


### PR DESCRIPTION
Tags are currently case-sensitive, causing problems with related posts and duplicate tags. For instance, a post tagged "test" won't be related to one tagged "Test," and both appear as separate tags on the tags page.