### PR TITLE
fix <title> not closing properly

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -22,9 +22,6 @@ import { join } from 'path'
 import { AstroFont } from 'astro-font'
 ---
 
-<!-- ViewTransitions  -->
-<ViewTransitions />
-
 <!-- Global Metadata -->
 <meta charset='utf-8' />
 <meta name='viewport' content='width=device-width,initial-scale=1' />
@@ -36,6 +33,9 @@ import { AstroFont } from 'astro-font'
 
 <!-- Primary Meta Tags -->
 <title>{siteTitle}</title>
+
+<!-- ViewTransitions  -->
+<ViewTransitions />
 
 <!-- SEO -->
 <meta name='title' content={siteTitle} />


### PR DESCRIPTION
The <title> tag is broken and doesn't close properly, resulting in the title text having "`<-- SEO --> <meta ... `" appended to `{siteTitle}`, and the </title> tag appearing after all the <meta> tags

Not sure why, but reverting the change in commit b3658d3 to `src/components/BaseHead.astro` fixes this.