### PR TITLE
fix(a11y): add aria label for button without text content

### DIFF
--- a/src/components/ToggleTheme.astro
+++ b/src/components/ToggleTheme.astro
@@ -33,7 +33,7 @@ import MoonIcon from '@/components/icons/MoonIcon'
 </script>
 
 <theme-toggle class='relative h-6 w-6'>
-	<button id='toggle-theme' class='group'>
+	<button id='toggle-theme' class='group' aria-label='Toggle Theme'>
 		<span class='absolute left-0 right-0 top-0 opacity-0 group-aria-pressed:opacity-100'>
 			<SunIcon />
 		</span>


### PR DESCRIPTION
![image](https://github.com/danielcgilibert/blog-template/assets/41441643/de3f17cd-2f7d-46ce-8ebe-57a0f18df2e4)
