### PR TITLE
Replace TableOfContents.astro h1 tag with p

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -29,7 +29,7 @@ function buildToc(headings: TableOfContent[]) {
 ---
 
 <nav class='max-w-xs dark:text-black'>
-	<h1 class='font-bold mb-3 text-2xl dark:text-white'>Index</h1>
+	<p class='font-bold mb-3 text-2xl dark:text-white'>Index</p>
 	<ul class='[text-wrap:balance] flex flex-col gap-1'>
 		{toc.map((heading) => <TableOfContentsHeading heading={heading} />)}
 	</ul>


### PR DESCRIPTION
In ahrefs's site audit, it complains that the web page has multiple `<h1>` tags. 

Replacing the `<h1>` tag of TOC with `<p>` should solve this issue.

Reference: [ahrefs - What is H1 Tag?](https://ahrefs.com/seo/glossary/h1-tag#:~:text=Yes%2C%20it%20is%20absolutely%20safe,the%20heading%20structure%20more%20consistent.)