### PR TITLE
fix: handle special characters in tag URLs

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -5,7 +5,7 @@ export interface Props {
 const { tag } = Astro.props
 ---
 
-<a href={`/tags/${tag.toLowerCase()}`} aria-label={tag}>
+<a href={`/tags/${encodeURIComponent(tag.toLowerCase())}`} aria-label={tag}>
 	<span
 		class='bg-indigo-600 font-semibold text-white dark:bg-indigo-900 dark:text-white shadow text-sm w-fit px-2 py-1 md:px-5 md:py-2 rounded-full'
 	>


### PR DESCRIPTION
When the tag contains special characters like '#', the generated URL becomes invalid due to the presence of these characters. This commit fixes the issue by encoding the tag using `encodeURIComponent` before constructing the URL.

Changes:
- Use `encodeURIComponent` to encode the tag to ensure special characters are properly handled.
- Update the href attribute in the <a> tag to use the encoded tag.

Now, tags with special characters (e.g., 'C#') will generate valid URLs.