### PR TITLE
fix: Exclude drafts for categories and tags

### DIFF
--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -2,7 +2,9 @@ import { getCollection } from 'astro:content'
 
 export const getCategories = async () => {
 	const posts = await getCollection('blog')
-	const categories = new Set(posts.map((post) => post.data.category))
+	const categories = new Set(
+		posts.filter((post) => !post.data.draft).map((post) => post.data.category)
+	)
 	return Array.from(categories)
 }
 
@@ -16,11 +18,13 @@ export const getPosts = async (max?: number) => {
 export const getTags = async () => {
 	const posts = await getCollection('blog')
 	const tags = new Set()
-	posts.forEach((post) => {
-		post.data.tags.forEach((tag) => {
-			tags.add(tag.toLowerCase())
+	posts
+		.filter((post) => !post.data.draft)
+		.forEach((post) => {
+			post.data.tags.forEach((tag) => {
+				tags.add(tag.toLowerCase())
+			})
 		})
-	})
 
 	return Array.from(tags)
 }
@@ -28,12 +32,16 @@ export const getTags = async () => {
 export const getPostByTag = async (tag: string) => {
 	const posts = await getPosts()
 	const lowercaseTag = tag.toLowerCase()
-	return posts.filter((post) => {
-		return post.data.tags.some((postTag) => postTag.toLowerCase() === lowercaseTag)
-	})
+	return posts
+		.filter((post) => !post.data.draft)
+		.filter((post) => {
+			return post.data.tags.some((postTag) => postTag.toLowerCase() === lowercaseTag)
+		})
 }
 
 export const filterPostsByCategory = async (category: string) => {
 	const posts = await getPosts()
-	return posts.filter((post) => post.data.category.toLowerCase() === category)
+	return posts
+		.filter((post) => !post.data.draft)
+		.filter((post) => post.data.category.toLowerCase() === category)
 }


### PR DESCRIPTION
Expected Behavior: Tags and categories only used in drafts should not display in dev or prod output.

Observed Behavior: Tags and categories only used in drafts were showing up and producing empty summary pages such as `/category/foo/1` and `/tags/bar`.

---

This change eliminates drafts from impacting all public facing outputs.