### PR TITLE
split social links config from Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pnpm dev
   - favicon
   - robots.txt -> update the Sitemap url to your own domain
   - open-graph -> the open-graph is the image that will be displayed when sharing the blog link. For posts, the preview image is the post cover.
-- Edit the social networks in the Header component - **src/components/Header.astro**, change the URL to your social network.
+- Edit the social networks in **src/data/links.ts**, change the URL to your social network.
 
 ## 🗂️ Adding a category
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,26 +1,10 @@
 ---
 import HeaderLink from '@/components/HeaderLink'
-import TwitterIcon from '@/components/icons/TwitterIcon'
-import GithubIcon from '@/components/icons/GithubIcon'
 import MenuIcon from './icons/MenuIcon.astro'
 import Search from '@/components/Search'
 import TagIcon from './icons/TagIcon.astro'
 import ToggleTheme from './ToggleTheme.astro'
-
-// ADD YOUR SOCIAL NETWORKS HERE
-const SOCIALNETWORKS = [
-	{
-		name: 'Github',
-		url: 'https://github.com/danielcgilibert/blog-template',
-		icon: GithubIcon
-	},
-
-	{
-		name: 'Twitter',
-		url: 'https://github.com/danielcgilibert/blog-template',
-		icon: TwitterIcon
-	}
-]
+import { SOCIALNETWORKS } from '@/data/links'
 ---
 
 <header class='relative flex items-center h-12 font-semibold'>

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,0 +1,17 @@
+import TwitterIcon from '@/components/icons/TwitterIcon'
+import GithubIcon from '@/components/icons/GithubIcon'
+
+// ADD YOUR SOCIAL NETWORKS HERE
+export const SOCIALNETWORKS = [
+	{
+		name: 'Github',
+		url: 'https://github.com/danielcgilibert/blog-template',
+		icon: GithubIcon
+	},
+
+	{
+		name: 'Twitter',
+		url: 'https://github.com/danielcgilibert/blog-template',
+		icon: TwitterIcon
+	}
+] as const


### PR DESCRIPTION
This avoids conflicts with refactor and styling changes.