### PR TITLE
Filter out empty tags

### DIFF
--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -25,7 +25,9 @@ export const getTags = async () => {
 		.filter((post) => !post.data.draft)
 		.forEach((post) => {
 			post.data.tags.forEach((tag) => {
-				tags.add(tag.toLowerCase())
+				if (tag != '') {
+					tags.add(tag.toLowerCase())
+				}
 			})
 		})
 
@@ -48,3 +50,4 @@ export const filterPostsByCategory = async (category: string) => {
 		.filter((post) => !post.data.draft)
 		.filter((post) => post.data.category.toLowerCase() === category)
 }
+


### PR DESCRIPTION
When a tags is left in empty string (`[ '' ]` ), it won't appear on the tags index page. This prevent showing an empty tags button on tags index that does nothing.